### PR TITLE
services: add TU Graz authentication service

### DIFF
--- a/apps/damap-frontend/src/app/app.module.ts
+++ b/apps/damap-frontend/src/app/app.module.ts
@@ -1,35 +1,37 @@
-import {APP_INITIALIZER, NgModule} from '@angular/core';
-import {AuthGuard, EnvBannerModule} from '@damap/core';
-import {HttpClient, HttpClientModule} from '@angular/common/http';
-import {TranslateLoader, TranslateModule} from '@ngx-translate/core';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
+import { AuthGuard, EnvBannerModule } from '@damap/core';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 
-import {APP_ROUTES} from './app.routes';
-import {AppComponent} from './app.component';
-import {AppStoreModule} from './store/app-store.module';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {BrowserModule} from '@angular/platform-browser';
-import {ConfigService} from './services/config.service';
-import {ConsentGuard} from './guard/consent.guard';
-import {ConsentModule} from './components/consent/consent.module';
-import {LayoutModule} from './components/layout/layout.module';
-import {MatSnackBarModule} from '@angular/material/snack-bar';
-import {MultiTranslateHttpLoader} from 'ngx-translate-multi-http-loader';
-import {OAuthModule} from 'angular-oauth2-oidc';
-import {ReactiveFormsModule} from '@angular/forms';
-import {RouterModule} from '@angular/router';
-import {environment} from '../environments/environment';
+import { APP_ROUTES } from './app.routes';
+import { AppComponent } from './app.component';
+import { AppStoreModule } from './store/app-store.module';
+import { AuthService } from '../../../../libs/damap/src';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { BrowserModule } from '@angular/platform-browser';
+import { ConfigService } from './services/config.service';
+import { ConsentGuard } from './guard/consent.guard';
+import { ConsentModule } from './components/consent/consent.module';
+import { LayoutModule } from './components/layout/layout.module';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MultiTranslateHttpLoader } from 'ngx-translate-multi-http-loader';
+import { OAuthModule } from 'angular-oauth2-oidc';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { TuGrazAuthService } from './services/tugrazAuth.service';
+import { environment } from '../environments/environment';
 
 // required for AOT compilation
 export function HttpLoaderFactory(http: HttpClient): MultiTranslateHttpLoader {
   return new MultiTranslateHttpLoader(http, [
-    {prefix: './assets/i18n/layout/', suffix: '.json'},
-    {prefix: './assets/i18n/consent/', suffix: '.json'},
-    {prefix: './assets/damap-core/i18n/dashboard/', suffix: '.json'},
-    {prefix: './assets/damap-core/i18n/plans/', suffix: '.json'},
-    {prefix: './assets/damap-core/i18n/http/', suffix: '.json'},
-    {prefix: './assets/damap-core/i18n/gdpr/', suffix: '.json'},
-    {prefix: './assets/damap-core/i18n/', suffix: '.json'},
-    {prefix: './assets/i18n/', suffix: '.json'}
+    { prefix: './assets/i18n/layout/', suffix: '.json' },
+    { prefix: './assets/i18n/consent/', suffix: '.json' },
+    { prefix: './assets/damap-core/i18n/dashboard/', suffix: '.json' },
+    { prefix: './assets/damap-core/i18n/plans/', suffix: '.json' },
+    { prefix: './assets/damap-core/i18n/http/', suffix: '.json' },
+    { prefix: './assets/damap-core/i18n/gdpr/', suffix: '.json' },
+    { prefix: './assets/damap-core/i18n/', suffix: '.json' },
+    { prefix: './assets/i18n/', suffix: '.json' },
   ]);
 }
 
@@ -77,8 +79,11 @@ export function HttpLoaderFactory(http: HttpClient): MultiTranslateHttpLoader {
     },
     AuthGuard,
     ConsentGuard,
+    {
+      provide: AuthService,
+      useClass: TuGrazAuthService,
+    },
   ],
   bootstrap: [AppComponent],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/apps/damap-frontend/src/app/services/tugrazAuth.service.ts
+++ b/apps/damap-frontend/src/app/services/tugrazAuth.service.ts
@@ -1,0 +1,19 @@
+import { AuthService } from '../../../../../libs/damap/src';
+import { Injectable } from '@angular/core';
+import { OAuthService } from 'angular-oauth2-oidc';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TuGrazAuthService extends AuthService {
+
+  constructor(private _oAuthService: OAuthService) {
+    super(_oAuthService);
+  }
+
+  isAdmin(): boolean {
+    const parts: string[] = this._oAuthService.getAccessToken().split('.');
+    const tokenBody: any = JSON.parse('' + window.atob(parts[1]));
+    return tokenBody.resource_access?.[this._oAuthService.clientId ?? ""]?.roles?.includes('Damap Admin');
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/tuwien-csd/damap-backend/blob/next/CONTRIBUTING.md#pullrequests -->

## Description
<!-- Please select a type that best describes your PR -->
Config

#### What does this PR do?
<!-- Changes introduced by this PR - what happened before, what happens now -->
Auth token received from TU Graz SSO does not provide the roles via `realm_access` but via `resource_access.<client_id>`.
A specific authentication service has been created, which will look for the roles in the right place.
This service was configured to be used instead of the base service of DAMAP.

#### Breaking changes
<!-- Whether this PR contains breaking changes and which -->
None.

#### Code review focus
<!-- What you want the reviewer to focus on -->


#### Dependencies
<!-- If this PR depends on or requires other/additional (backend) changes, please list them here -->
None.

### Checks
<!-- Adjust list as necessary -->
- [ ] Summary updated
- [ ] Version view updated
- [ ] Documentation added
- [ ] Tests added
- [ ] E2e tests created
- [ ] Successfully ran e2e tests before merge

closes GH-4
